### PR TITLE
Make deployment variables sensitive 

### DIFF
--- a/bitbucket/resource_deployment_variable.go
+++ b/bitbucket/resource_deployment_variable.go
@@ -45,8 +45,9 @@ func resourceDeploymentVariable() *schema.Resource {
 				Required: true,
 			},
 			"value": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"secured": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Setting Sensitive to true so Terraform hides variable values from the CLI output, as they often contain sensitive credentials.